### PR TITLE
feat(package): react-native is removed as dep in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "reset": "git clean -dfx && git reset --hard && npm i",
     "all": "run-s reset test cov:check doc:html",
     "size": "size-limit",
+    "prepublishOnly": "npm uninstall react-native --save",
     "storybook:start": "bluebase storybook:start",
     "storybook-native": "bluebase storybook-native:start",
     "storybook": "start-storybook -p 6006 --config-dir ./bluebase/storybook/configs",


### PR DESCRIPTION
We need to remove react-native in the final release, otherwise react-native throws errors because of duplicate dependencies in the project.