### PR TITLE
chore(package.json): updated prepublish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "reset": "git clean -dfx && git reset --hard && npm i",
     "all": "run-s reset test cov:check doc:html",
     "size": "size-limit",
-    "prepublishOnly": "npm uninstall react-native --save",
+    "prepublishOnly": "yarn remove react-native",
     "storybook:start": "bluebase storybook:start",
     "storybook-native": "bluebase storybook-native:start",
     "storybook": "start-storybook -p 6006 --config-dir ./bluebase/storybook/configs",


### PR DESCRIPTION
As the package `@types/storybook__addon-knobs` has been deprecated, when `npm uninstalll` runs it doesn't use the yarn.lock file and tries to install all the fresh packages. So moved it to `yarn remove`. It won't cause the same issue. 